### PR TITLE
feat(details): MovieDetails view + banner card

### DIFF
--- a/src/components/MovieBackdrop.jsx
+++ b/src/components/MovieBackdrop.jsx
@@ -1,0 +1,27 @@
+import { backdropUrl } from "../features/api";
+
+export default function MovieBackdrop({
+  path,
+  alt = "",
+  fit = "cover",
+  position = "50% 20%",
+  ratio = "21 / 9",
+}) {
+  if (!path?.trim()) return <div className="hero__placeholder" />;
+
+  const src = backdropUrl(path, "w1280");
+
+  return (
+    <img
+      className="hero__img"
+      src={src}
+      alt={alt}
+      style={{
+        width: "100%",
+        aspectRatio: ratio,
+        objectFit: fit,
+        objectPosition: position,
+      }}
+    />
+  );
+}

--- a/src/features/api.js
+++ b/src/features/api.js
@@ -6,6 +6,11 @@ export function posterUrl(path) {
   return path ? IMG + path : "";
 }
 
+/**
+ * Search movies by text using TMDb Search endpoint.
+ * API: GET /search/movie
+ * @see https://developer.themoviedb.org/reference/search-movie
+ */
 export function queryString(params) {
   return new URLSearchParams(params).toString();
 }

--- a/src/features/api.js
+++ b/src/features/api.js
@@ -75,7 +75,6 @@ export async function getRecentlyReleasedMovies({
     });
 
   try {
-
     const response = await fetch(url);
     if (!response.ok) throw new Error(`TMDb ${response.status}`);
     const json = await response.json();
@@ -94,3 +93,25 @@ export async function getRecentlyReleasedMovies({
   }
 }
 
+/**
+ * Fetch TMDB Movie Details for a given ID
+ * API: GET /movie/{movie_id}
+ * @see https://developer.themoviedb.org/reference/movie-details
+ */
+export async function getMovieById(id, { language = "sv-SE" } = {}) {
+  const movieId = Number(id);
+  if (!Number.isFinite(movieId)) return null;
+
+  const url =
+    `${BASE}/movie/${movieId}?` + queryString({ api_key: API_KEY, language });
+  console.log("getMovieById ->", url);
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`TMDb ${response.status}`);
+    return await response.json();
+  } catch (error) {
+    console.error("getMovieById failed:", error);
+    return null;
+  }
+}

--- a/src/features/api.js
+++ b/src/features/api.js
@@ -1,10 +1,10 @@
 const API_KEY = import.meta.env.VITE_TMDB_API_KEY;
 const BASE = "https://api.themoviedb.org/3";
-const IMG = "https://image.tmdb.org/t/p/w500";
+const IMG_BASE = "https://image.tmdb.org/t/p";
 
-export function posterUrl(path) {
-  return path ? IMG + path : "";
-}
+export const posterUrl   = (path, size = "w342")  => path ? `${IMG_BASE}/${size}${path}` : "";
+export const backdropUrl = (path, size = "w1280") => path ? `${IMG_BASE}/${size}${path}` : "";
+
 
 /**
  * Search movies by text using TMDb Search endpoint.

--- a/src/pages/MovieDetails.jsx
+++ b/src/pages/MovieDetails.jsx
@@ -17,8 +17,8 @@ export default function MovieDetails() {
     setError(false);
 
     getMovieById(id)
-      .then((movie) => {
-        if (!cancelled) setMovie(movie);
+      .then((m) => {
+        if (!cancelled) setMovie(m);
       })
       .catch(() => {
         if (!cancelled) setError(true);
@@ -26,6 +26,7 @@ export default function MovieDetails() {
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
+
     return () => {
       cancelled = true;
     };
@@ -35,11 +36,15 @@ export default function MovieDetails() {
     return (
       <div className="details">
         <header className="details__header">
+          <div className="details__container">
+            <h1 className="details__title">Laddar...</h1>
+          </div>
+        </header>
+        <footer className="details__footer">
           <Link className="details__back" to="/">
             Tillbaka
           </Link>
-          <h1 className="details__title">Laddar...</h1>
-        </header>
+        </footer>
       </div>
     );
   }
@@ -48,12 +53,18 @@ export default function MovieDetails() {
     return (
       <div className="details">
         <header className="details__header">
+          <div className="details__container">
+            <h1 className="details__title">Ingen filminformation</h1>
+          </div>
+        </header>
+        <div className="details__container">
+          <p className="details__empty">Prova att gå dit via sökningen igen</p>
+        </div>
+        <footer className="details__footer">
           <Link className="details__back" to="/">
             Tillbaka
           </Link>
-          <h1 className="details__title">Ingen filminformation</h1>
-        </header>
-        <p className="details__empty">Prova att gå dit via sökningen igen</p>
+        </footer>
       </div>
     );
   }
@@ -67,31 +78,46 @@ export default function MovieDetails() {
   return (
     <div className="details">
       <header className="details__header">
-        <Link className="details__back" to="/">
-          Tillbaka
-        </Link>
-        <h1 className="details__title">{title}</h1>
+        <div className="details__container">
+          <h1 className="details__title">{title}</h1>
+        </div>
       </header>
 
       <section className="details__hero">
-        <MovieBackdrop path={bannerImagePath} alt={title} />
+        <div className="details__container">
+          <MovieBackdrop path={bannerImagePath} alt={title} />
+        </div>
       </section>
 
       <section className="details__main">
-        <div className="details__info">
-          <div className="details__meta">
-            <span className="details__meta-item">År: {year}</span>
-            <span className="details__meta-item">Betyg: {rating}</span>
-          </div>
-          <p className="details__overview">
-            {movie.overview || "Ingen beskrivning tillgänglig"}
-          </p>
-          <div className="details__price">
-            <span>Pris</span>
-            <strong>{displayPrice}</strong>
+        <div className="details__container">
+          <div className="details__info">
+            <div className="details__meta">
+              <span className="details__meta-item">År: {year}</span>
+              <span className="details__meta-item">Betyg: {rating}</span>
+            </div>
+
+            <p className="details__overview">
+              {movie.overview || "Ingen beskrivning tillgänglig"}
+            </p>
+
+            <div className="details__price">
+              <span>Pris</span>
+              <strong>{displayPrice}</strong>
+            </div>
           </div>
         </div>
       </section>
+
+      <footer className="details__footer">
+        <Link className="details__back" to="/">
+          Tillbaka
+        </Link>
+      </footer>
     </div>
   );
 }
+
+// priser för köpa, hyra och affisch
+// mera meta data
+// extrahera kod till egna komponentner?

--- a/src/pages/MovieDetails.jsx
+++ b/src/pages/MovieDetails.jsx
@@ -1,13 +1,102 @@
-import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { getMovieById } from "../features/api";
+import { formatSEK, priceFromId } from "../utils/format";
 import "./movieDetails.css";
+import MoviePoster from "../components/MoviePoster";
 
-const movieDetails = () => {
+export default function MovieDetails() {
+  const { id } = useParams();
+  const [movie, setMovie] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(false);
+
+    getMovieById(id)
+      .then((movie) => {
+        if (!cancelled) setMovie(movie);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="details">
+        <header className="details__header">
+          <Link className="details__back" to="/">
+            Tillbaka
+          </Link>
+          <h1 className="details__title">Laddar...</h1>
+        </header>
+      </div>
+    );
+  }
+
+  if (error || !movie) {
+    return (
+      <div className="details">
+        <header className="details__header">
+          <Link className="details__back" to="/">
+            Tillbaka
+          </Link>
+          <h1 className="details__title">Ingen filminformation</h1>
+        </header>
+        <p className="details__empty">Prova att gå dit via sökningen igen</p>
+      </div>
+    );
+  }
+
+  const title = movie.title ?? movie.original_title ?? "Ingen titel funnen";
+  const year = movie.release_date?.slice(0, 4) ?? "—";
+  const year1 = movie.release_date?.slice()
+  const displayPrice = formatSEK(priceFromId(Number(movie.id)));
+  const rating = Number.isFinite(movie?.vote_average) ? movie.vote_average.toFixed(1) : "—";
+  
   return (
-    <div>
-      movieDetails
+    <div className="details">
+      <header className="details__header">
+        <Link className="details__back" to="/">
+          Tillbaka
+        </Link>
+        <h1 className="details__title">{title}</h1>
+      </header>
 
+      <section className="details__main">
+        <MoviePoster
+          path={movie.poster_path}
+          alt={title}
+          width={160}
+          height={240}
+        />
+
+        <div className="details__info">
+          <div className="details__meta">
+            <span className="details__meta-item">År: {year}</span>
+            <span className="details__meta-item">Betyg: {rating}</span>
+          </div>
+
+          <p className="details__overview">
+            {movie.overview || "Ingen beskrivning tillgänglig"}
+          </p>
+
+          <div className="details__price">
+            <span>Pris</span>
+            <strong>{displayPrice}</strong>
+          </div>
+        </div>
+      </section>
     </div>
   );
-};
-
-export default movieDetails;
+}

--- a/src/pages/MovieDetails.jsx
+++ b/src/pages/MovieDetails.jsx
@@ -3,7 +3,7 @@ import { useParams, Link } from "react-router-dom";
 import { getMovieById } from "../features/api";
 import { formatSEK, priceFromId } from "../utils/format";
 import "./movieDetails.css";
-import MoviePoster from "../components/MoviePoster";
+import MovieBackdrop from "../components/MovieBackdrop";
 
 export default function MovieDetails() {
   const { id } = useParams();
@@ -60,10 +60,10 @@ export default function MovieDetails() {
 
   const title = movie.title ?? movie.original_title ?? "Ingen titel funnen";
   const year = movie.release_date?.slice(0, 4) ?? "—";
-  const year1 = movie.release_date?.slice()
   const displayPrice = formatSEK(priceFromId(Number(movie.id)));
-  const rating = Number.isFinite(movie?.vote_average) ? movie.vote_average.toFixed(1) : "—";
-  
+  const rating = Number.isFinite(movie?.vote_average) ? movie.vote_average.toFixed(1): "—";
+  const bannerImagePath = movie.backdrop_path || movie.poster_path;
+
   return (
     <div className="details">
       <header className="details__header">
@@ -73,24 +73,19 @@ export default function MovieDetails() {
         <h1 className="details__title">{title}</h1>
       </header>
 
-      <section className="details__main">
-        <MoviePoster
-          path={movie.poster_path}
-          alt={title}
-          width={160}
-          height={240}
-        />
+      <section className="details__hero">
+        <MovieBackdrop path={bannerImagePath} alt={title} />
+      </section>
 
+      <section className="details__main">
         <div className="details__info">
           <div className="details__meta">
             <span className="details__meta-item">År: {year}</span>
             <span className="details__meta-item">Betyg: {rating}</span>
           </div>
-
           <p className="details__overview">
             {movie.overview || "Ingen beskrivning tillgänglig"}
           </p>
-
           <div className="details__price">
             <span>Pris</span>
             <strong>{displayPrice}</strong>

--- a/src/pages/movieDetails.css
+++ b/src/pages/movieDetails.css
@@ -1,13 +1,103 @@
+.details {
+  display: grid;
+  gap: 16px;
+  padding-inline: 24px;
+}
+
+.details__container {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.details__header {
+  margin-top: 12px;
+}
+
+.details__title {
+  margin: 0;
+  font-size: clamp(20px, 2.5vw, 28px);
+  font-weight: 700;
+  color: white;
+}
+
 .details__hero {
-  position: relative;
   margin: 12px 0 16px;
+}
+
+.hero__img {
+  display: block;
+  width: 100%;
+  height: auto;
   border-radius: 20px;
-  overflow: hidden;
-  background: black;
 }
 
 .hero__placeholder {
   width: 100%;
   aspect-ratio: 16 / 9;
   background: dimgray;
+  border-radius: 20px;
+}
+
+.details__main {
+  padding-bottom: 24px;
+}
+
+/* Card */
+.details__info {
+  width: 100%;
+  max-width: none;
+  box-sizing: border-box;
+  padding: 12px 16px;
+  border-radius: 20px;
+  background: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  color: gainsboro;
+  text-align: left;
+}
+
+.details__meta {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 8px;
+  font-size: 14px;
+  opacity: 0.9;
+}
+
+.details__overview {
+  line-height: 1.6;
+  margin: 10px 0 16px;
+  text-wrap: pretty;
+}
+
+.details__price {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 15px;
+}
+
+.details__empty {
+  opacity: 0.9;
+  margin-top: 8px;
+  text-align: left;
+  color: gainsboro;
+}
+
+.details__footer {
+  display: grid;
+  place-items: center;
+  padding: 8px 0 24px;
+}
+
+.details__back {
+  display: inline-block;
+  padding: 6px 12px;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.15);
+  color: white;
 }

--- a/src/pages/movieDetails.css
+++ b/src/pages/movieDetails.css
@@ -1,0 +1,13 @@
+.details__hero {
+  position: relative;
+  margin: 12px 0 16px;
+  border-radius: 20px;
+  overflow: hidden;
+  background: black;
+}
+
+.hero__placeholder {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background: dimgray;
+}


### PR DESCRIPTION
- add MovieDetails page (route :id) with loading/error/empty
- API: add getMovieById(id, { language: "sv-SE" })
- docs: JSDoc for search/details endpoints
- images: centralize TMDb IMG_BASE + posterUrl/backdropUrl
- UI: new MovieBackdrop (backdrop or poster) as hero banner
- CSS: rounded hero, hero/placeholder styles
- layout: shared `.details__container` (max 1100px, centered)
- UI: add blurred “info” card with left-aligned text
- nav: move Back link to centered footer (also in loading/error)

No breaking changes, affects Details page and API helpers.