### PR TITLE
refactor: MovieDetails fetch, update movie meta

### DIFF
--- a/src/components/MovieMeta.jsx
+++ b/src/components/MovieMeta.jsx
@@ -1,0 +1,43 @@
+import {
+  formatRuntimeOrDash,
+  formatGenres,
+  getTopCastNames,
+  getDirectorNames,
+  formatYearOrDash,
+  formatVoteAverageOrDash,
+} from "../utils/movieMeta";
+
+export default function MovieMeta({ movie, castCount = 3 }) {
+  if (!movie) return null;
+
+  const crew = movie.credits?.crew ?? [];
+  const cast = movie.credits?.cast ?? [];
+
+  const year = formatYearOrDash(movie.release_date);
+  const rating = formatVoteAverageOrDash(movie.vote_average);
+  const runtime = formatRuntimeOrDash(movie.runtime);
+  const genresText = formatGenres(movie.genres, 3);
+  const director = getDirectorNames(crew);
+  const topCast = getTopCastNames(cast, castCount);
+
+  return (
+    <>
+      <div className="details__meta">
+        <span className="details__meta-item">År: {year}</span>
+        <span className="details__meta-item">Betyg: {rating}</span>
+        {runtime !== "—" && (
+          <span className="details__meta-item">Längd: {runtime}</span>
+        )}
+        {genresText !== "—" && (
+          <span className="details__meta-item">Genre: {genresText}</span>
+        )}
+        {director && (
+          <span className="details__meta-item">Regi: {director}</span>
+        )}
+        {topCast !== "—" && (
+          <span className="details__meta-item">Medverkande: {topCast}</span>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/features/api.js
+++ b/src/features/api.js
@@ -103,20 +103,18 @@ export async function getRecentlyReleasedMovies({
  * API: GET /movie/{movie_id}
  * @see https://developer.themoviedb.org/reference/movie-details
  */
-export async function getMovieById(id, { language = "sv-SE" } = {}) {
+export async function getMovieById(
+  id,
+  { language = "sv-SE", append = "credits" } = {}
+) {
   const movieId = Number(id);
   if (!Number.isFinite(movieId)) return null;
 
   const url =
-    `${BASE}/movie/${movieId}?` + queryString({ api_key: API_KEY, language });
-  console.log("getMovieById ->", url);
+    `${BASE}/movie/${movieId}?` +
+    queryString({ api_key: API_KEY, language, append_to_response: append });
 
-  try {
-    const response = await fetch(url);
-    if (!response.ok) throw new Error(`TMDb ${response.status}`);
-    return await response.json();
-  } catch (error) {
-    console.error("getMovieById failed:", error);
-    return null;
-  }
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`TMDb ${res.status}`);
+  return await res.json();
 }

--- a/src/pages/MovieDetails.jsx
+++ b/src/pages/MovieDetails.jsx
@@ -4,6 +4,7 @@ import { getMovieById } from "../features/api";
 import { formatSEK, priceFromId } from "../utils/format";
 import "./movieDetails.css";
 import MovieBackdrop from "../components/MovieBackdrop";
+import MovieMeta from "../components/MovieMeta";
 
 export default function MovieDetails() {
   const { id } = useParams();
@@ -12,24 +13,13 @@ export default function MovieDetails() {
   const [error, setError] = useState(false);
 
   useEffect(() => {
-    let cancelled = false;
     setLoading(true);
     setError(false);
 
     getMovieById(id)
-      .then((m) => {
-        if (!cancelled) setMovie(m);
-      })
-      .catch(() => {
-        if (!cancelled) setError(true);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
+      .then(setMovie)
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
   }, [id]);
 
   if (loading) {
@@ -70,10 +60,8 @@ export default function MovieDetails() {
   }
 
   const title = movie.title ?? movie.original_title ?? "Ingen titel funnen";
-  const year = movie.release_date?.slice(0, 4) ?? "—";
-  const displayPrice = formatSEK(priceFromId(Number(movie.id)));
-  const rating = Number.isFinite(movie?.vote_average) ? movie.vote_average.toFixed(1): "—";
   const bannerImagePath = movie.backdrop_path || movie.poster_path;
+  const displayPrice = formatSEK(priceFromId(Number(movie.id)));
 
   return (
     <div className="details">
@@ -92,10 +80,7 @@ export default function MovieDetails() {
       <section className="details__main">
         <div className="details__container">
           <div className="details__info">
-            <div className="details__meta">
-              <span className="details__meta-item">År: {year}</span>
-              <span className="details__meta-item">Betyg: {rating}</span>
-            </div>
+            <MovieMeta movie={movie} castCount={3} />
 
             <p className="details__overview">
               {movie.overview || "Ingen beskrivning tillgänglig"}
@@ -119,5 +104,6 @@ export default function MovieDetails() {
 }
 
 // priser för köpa, hyra och affisch
-// mera meta data
 // extrahera kod till egna komponentner?
+// lägga till css för MovieMeta.jsx
+// navigera genom search till details

--- a/src/utils/movieMeta.js
+++ b/src/utils/movieMeta.js
@@ -1,0 +1,52 @@
+/** Formats runtime (minutes) into Swedish text, returns "—" if invalid. */
+export function formatRuntimeOrDash(minutes) {
+  if (!(minutes > 0)) return "-";
+  const wholeHours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return wholeHours
+    ? `${wholeHours} timmar ${remainingMinutes} minuter`
+    : `${remainingMinutes} minuter`;
+}
+
+/**
+ * Formats a genre list [{name}] into "Action, Komedi".
+ * Limits how many items to show and joins with a separator. Empty -> "-".
+ */
+export function formatGenres(genreList = [], maxGenres = 3, separator = ", ") {
+  const list = Array.isArray(genreList) ? genreList : [];
+  const names = list.slice(0, maxGenres).map((genre) => genre?.name);
+  return names.length ? names.join(separator) : "—";
+}
+
+/**
+ * Returns up to `maxToShow` cast member names, joined with `joinWith`.
+ * Assumes TMDB cast is usually pre-sorted. Empty -> "—".
+ */
+export function getTopCastNames(castList = [], maxToShow = 3, joinWith = ", ") {
+  const names = (Array.isArray(castList) ? castList : [])
+    .slice(0, maxToShow)
+    .map((castMember) => castMember?.name);
+  return names.length ? names.join(joinWith) : "—";
+}
+
+/**
+ * Returns all director names (may be multiple) as a comma-separated string.
+ * No directors found -> null (so the UI can hide the field).
+ */
+export function getDirectorNames(crewList = [], joinWith = ", ") {
+  const directorNames = (Array.isArray(crewList) ? crewList : [])
+    .filter((person) => person?.job === "Director")
+    .map((person) => person?.name);
+  return directorNames.length ? directorNames.join(joinWith) : null;
+}
+
+// Returns "YYYY" from a date string (e.g. "1998-07-15"), otherwise "—".
+export function formatYearOrDash(dateString) {
+  return dateString.length >= 4 ? dateString.slice(0, 4) : "—";
+}
+
+// Formats a TMDB rating to one decimal place, otherwise "—".
+export function formatVoteAverageOrDash(voteAverage) {
+  const numericValue = Number(voteAverage);
+  return Number.isFinite(numericValue) ? numericValue.toFixed(1) : "—";
+}


### PR DESCRIPTION
- utils/movieMeta.js: clearer names/comments, defensive arrays.
- MovieDetails.jsx: remove `cancelled`, keep loading/error logic simple.
- api.js: lean getMovieById with default "credits".
- MovieMeta.jsx: use getDirectorNames, remove age/tagline/country.