### PR TITLE
feat: add YouTube trailer button on details

### DIFF
--- a/src/components/TrailerButton.jsx
+++ b/src/components/TrailerButton.jsx
@@ -1,0 +1,27 @@
+/**
+ * Open a YouTube trailer for a movie, fallback to a YouTube search.
+ * Expects TMDB `videos.results` (from append_to_response=videos).
+ * Priority: official YouTube Trailer > any YouTube Trailer > any YouTube video, else search "<title> trailer".
+ * @param {string} movieTitle    Title used for fallback search.
+ * @param {Array}  videoResults  TMDB videos.results array.
+ */
+import "./TrailerButton.css";
+export default function TrailerButton({ movieTitle, videoResults }) {
+  const videoList = Array.isArray(videoResults) ? videoResults : [];
+
+  const bestYouTubeVideo =
+    videoList.find((video) => video.site === "YouTube" && video.type === "Trailer" && video.official) ??
+    videoList.find((video) => video.site === "YouTube" && video.type === "Trailer") ??
+    videoList.find((video) => video.site === "YouTube") ?? null;
+
+  const hasExactYouTubeTrailer = Boolean(bestYouTubeVideo?.key);
+
+  const trailerUrl = hasExactYouTubeTrailer ? `https://www.youtube.com/watch?v=${bestYouTubeVideo.key}` : `https://www.youtube.com/results?search_query=${encodeURIComponent(`${movieTitle} trailer`)}`;
+
+  return (
+    <a className="yt-play" href={trailerUrl} target="_blank" rel="noopener noreferrer">
+      <span className="yt-play__triangle" />
+
+    </a>
+  );
+}

--- a/src/components/trailerButton.css
+++ b/src/components/trailerButton.css
@@ -1,0 +1,29 @@
+.yt-play {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 9999px;
+  background: red;
+  transition: background-color 120ms ease, transform 120ms ease;
+}
+
+.yt-play:hover {
+  background: red;
+  transform: translateY(-1px);
+}
+
+.yt-play:active {
+  background: firebrick;
+  transform: translateY(0);
+}
+
+.yt-play__triangle {
+  width: 0;
+  height: 0;
+  border-left: 12px solid white;
+  border-top: 8px solid transparent;
+  border-bottom: 8px solid transparent;
+  margin-left: 2px;
+}

--- a/src/features/api.js
+++ b/src/features/api.js
@@ -102,10 +102,11 @@ export async function getRecentlyReleasedMovies({
  * Fetch TMDB Movie Details for a given ID
  * API: GET /movie/{movie_id}
  * @see https://developer.themoviedb.org/reference/movie-details
+ * @see https://developer.themoviedb.org/reference/movie-videos
  */
 export async function getMovieById(
   id,
-  { language = "sv-SE", append = "credits" } = {}
+  { language = "sv-SE", append = "credits,videos" } = {}
 ) {
   const movieId = Number(id);
   if (!Number.isFinite(movieId)) return null;

--- a/src/pages/MovieDetails.jsx
+++ b/src/pages/MovieDetails.jsx
@@ -5,6 +5,7 @@ import { formatSEK, priceFromId } from "../utils/format";
 import "./movieDetails.css";
 import MovieBackdrop from "../components/MovieBackdrop";
 import MovieMeta from "../components/MovieMeta";
+import TrailerButton from "../components/TrailerButton";
 
 export default function MovieDetails() {
   const { id } = useParams();
@@ -85,6 +86,8 @@ export default function MovieDetails() {
             <p className="details__overview">
               {movie.overview || "Ingen beskrivning tillgänglig"}
             </p>
+
+            <TrailerButton movieTitle={title} videoResult={movie.videos?.results}/>
 
             <div className="details__price">
               <span>Pris</span>


### PR DESCRIPTION
- add `TrailerButton.jsx` that picks best TMDB YouTube video, prefers official Trailer -> any Trailer -> any YouTube, else search result.
- Add `TrailerButton.css` (red circular play button with CSS triangle)
- wire `TrailerButton` into `MovieDetails.jsx` (after overview) passing `movieTitle` and `videos.results`
- update `getMovieById` default to `append=credits,videos` so trailer data is returned with movie details